### PR TITLE
changelog: clarify that not yet logging changes because not released

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,3 @@
 # myuw-launch-button versions
 
-2019-08-01
-
-First commit of launch button component.
+(Not yet released.)


### PR DESCRIPTION
It's not released yet, so we don't need to track what changed since the previous release. yet. 