### PR TITLE
fix name to match name of component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@myuw-web-components/myuw-badge",
+  "name": "@myuw-web-components/myuw-launch-button",
   "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
had been a copy-and-paste from myuw-badge. npm install automatically fixes this but even better to just correct it in the file.