### PR TITLE
use the public version of the example launch URL so will work for all

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
           <p class="title">Launch Button:</p>
           <p>
             <myuw-launch-button 
-              url="https://my.wisc.edu/web/apps/details/my-professional-development"
+              url="https://public.my.wisc.edu/web/apps/details/my-professional-development"
               buttonText="Open details page"
             >
             </myuw-launch-button>


### PR DESCRIPTION
Makes the localhost example a URL that anyone can launch, not requiring Madison login. Makes the demo just slightly more friendly for non-Madison developers of MyUW content.